### PR TITLE
New Feature: Mastersplit

### DIFF
--- a/cardano-accointing-exporter.py
+++ b/cardano-accointing-exporter.py
@@ -67,7 +67,7 @@ def main():
     # Handle exporter argument
     if args.exporter == 'accointing':
         exporter = exporters.accointing_exporter
-    if args.exporter == 'blockpit':
+    elif args.exporter == 'blockpit':
         exporter = exporters.blockpit_exporter
     elif args.exporter == 'generic':
         exporter = exporters.generic_exporter

--- a/cardano-accointing-exporter.py
+++ b/cardano-accointing-exporter.py
@@ -46,6 +46,14 @@ def main():
     parser.add_argument('--internals-file', type=str,
                         help='You can supply a file containing additional addresses that are used to determine internal transfers but are' +
                              ' not used for transaction history creation. One address or stake key per line.')
+    parser.add_argument('--mastersplit', type=int,
+                        help='You can supply an ADA number (e.g. 340) to split masternode deposit as follows: Masternode deposits will be reduced (up) to mastersplit value. ' +
+                             '  If there are left-over masternode rewards, generate three extra transactions with same date as masternode deposit: ' +
+                             ' 1. Deposit transaction of left-over ADA with classification Non-Taxable In' +
+                             ' 2. Withdraw transaction of left-over ADA with classification Payment' +
+                             ' 3. Deposit transaction of left-over ADA with classification Interest.'  +
+                             ' Additionally, after calculation, the total interest ADA within the calculated time window will be displayed on standard out.' +
+                             ' Note: Currently, this parameter is only implemented for the blockpit exporter')
     args = parser.parse_args()
 
     # Handle project id file argument
@@ -67,7 +75,7 @@ def main():
     # Handle exporter argument
     if args.exporter == 'accointing':
         exporter = exporters.accointing_exporter
-    if args.exporter == 'blockpit':
+    elif args.exporter == 'blockpit':
         exporter = exporters.blockpit_exporter
     elif args.exporter == 'generic':
         exporter = exporters.generic_exporter
@@ -98,6 +106,11 @@ def main():
         print(f'Internals file "{args.internals_file}" read successfully ', end='')
         print(u'\u2713')
     internals_counter = len(config.addresses)
+
+    # Handle mastersplit argument
+    mastersplit = 0
+    if args.mastersplit is not None:
+        mastersplit = args.mastersplit
 
     # Handle currency argument
     if args.currency is not None:
@@ -187,7 +200,10 @@ def main():
                     print('-- Get reward history')
                     print(f'---- for stake key {current_wallet.stake_address}')
                     current_wallet.rewards = koios.get_reward_history_for_account(current_wallet.stake_address, args.start_time, args.end_time)
-                    reward_history = exporter.export_reward_history_for_wallet(current_wallet, currency)
+                    if exporter is exporters.blockpit_exporter:
+                        reward_history = exporter.export_reward_history_for_wallet(current_wallet, currency, mastersplit)
+                    else:
+                        reward_history = exporter.export_reward_history_for_wallet(current_wallet, currency)
                     for row in reward_history:
                         add_row(row, csv_data)
                     stake_keys_calculated.add(current_wallet.stake_address)

--- a/cardano-accointing-exporter.py
+++ b/cardano-accointing-exporter.py
@@ -12,6 +12,7 @@ import config
 import endpoints.blockfrost as blockfrost
 import endpoints.koios as koios
 import exporters.accointing_exporter
+import exporters.blockpit_exporter
 import exporters.generic_exporter
 from config import URLS_EXPIRE_AFTER
 from endpoints import coingecko
@@ -25,7 +26,7 @@ def main():
                                                  'style using one of the available exporters. Note: not all exporters support all features.')
     parser.add_argument('--project-id-file', type=str, default='project.id', help='path to a file containing only your blockfrost.io ' +
                         'project id (has precedence over hard-coded project id in config.py, default: project.id)')
-    parser.add_argument('--exporter', type=str, default='accointing', help='the exporter to use (available: accointing, generic, default: accointing)')
+    parser.add_argument('--exporter', type=str, default='accointing', help='the exporter to use (available: accointing, blockpit, generic, default: accointing)')
     parser.add_argument('--purge-cache', help='removes the current cache; forcing refresh of API data', action='store_true')
     parser.add_argument('--start-time', type=lambda s: datetime.strptime(s, '%Y-%m-%d').replace(tzinfo=timezone.utc),
                         default=datetime.fromtimestamp(0, timezone.utc),
@@ -66,6 +67,8 @@ def main():
     # Handle exporter argument
     if args.exporter == 'accointing':
         exporter = exporters.accointing_exporter
+    if args.exporter == 'blockpit':
+        exporter = exporters.blockpit_exporter
     elif args.exporter == 'generic':
         exporter = exporters.generic_exporter
     else:

--- a/exporters/blockpit_exporter.py
+++ b/exporters/blockpit_exporter.py
@@ -76,7 +76,7 @@ def export_transaction_history_for_transactions(transactions: List[Transaction],
                            '',
                            tx.hash])
         else:
-            print(f'The transaction "{tx.hash}" has a derived output amount of zero, thus not matching any accointing classification. Skipping..')
+            print(f'The transaction "{tx.hash}" has a derived output amount of zero, thus not matching any blockpit classification. Skipping..')
 
         if config.classify_internal_txs:
             internal = True

--- a/exporters/blockpit_exporter.py
+++ b/exporters/blockpit_exporter.py
@@ -1,0 +1,123 @@
+from typing import List, Any
+
+import config
+from endpoints.blockfrost import get_withdrawal_for_transaction
+from shared.representations import Wallet, Transaction
+
+csv_header = ['Date (UTC)', 'Integration Name', 'Label', 'Outgoing Asset', 'Outgoing Amount', 'Incoming Asset', 'Incoming Amount',
+               'Fee Asset (optional)', 'Fee Amount (optional)','Comment (optional)', 'Trx. ID (optional)']
+sorting_key = 1
+
+
+def export_reward_history_for_wallet(wallet: Wallet, currency) -> List[Any]:
+    rewards = []
+    if len(wallet.rewards) > 0:
+        for reward in wallet.rewards:
+            amount = int(reward.amount) / 1000000
+            classification = ''
+            if reward.type == 'member':
+                classification = 'Staking'
+            elif reward.type == 'leader':
+                classification = 'Masternode'
+            elif reward.type == 'treasury' or reward.type == 'reserves':
+                classification = 'Bounty'
+            rewards.append([reward.reward_time, wallet.name.split('/')[1], classification, '', '', 'ADA', amount, '', '', '', ''])
+
+    return rewards
+
+
+def export_transaction_history_for_transactions(transactions: List[Transaction], wallet: Wallet, currency: str) -> List[List[Any]]:
+    tx_csv = []
+    for tx in transactions:
+        if tx.withdrawal_count > 0:
+            withdrawal = get_withdrawal_for_transaction(tx.hash).json()
+            withdrawal_address = withdrawal[0]['address']
+            withdrawal_amount = int(withdrawal[0]['amount'])
+            if withdrawal_address == wallet.stake_address:
+                tx.output_amount = [('lovelace', tx.output_amount[0][1] - withdrawal_amount)]
+
+        if tx.output_amount[0][1] < 0 and abs(tx.output_amount[0][1]) == tx.fees:
+            # fees
+            tx_csv.append([tx.block_time,
+                           wallet.name.split('/')[1],
+                           'Fee',
+                           'ADA',
+                           tx.fees / 1000000,
+                           '',
+                           '',
+                           '',
+                           '',
+                           '',
+                           tx.hash])
+        elif tx.output_amount[0][1] > 0:
+            # deposit
+            tx_csv.append([tx.block_time,
+                           wallet.name.split('/')[1],
+                           'Deposit',
+                           '',
+                           '',
+                           'ADA',
+                           tx.output_amount[0][1] / 1000000 + tx.fees / 1000000,
+                           'ADA',
+                           tx.fees / 1000000,
+                           '',
+                           tx.hash])
+        elif tx.output_amount[0][1] < 0:
+            # withdrawal
+            tx_csv.append([tx.block_time,
+                           wallet.name.split('/')[1],
+                           'Withdrawal',
+                           'ADA',
+                           abs(tx.output_amount[0][1]) / 1000000 - tx.fees / 1000000,
+                           '',
+                           '',
+                           'ADA',
+                           tx.fees / 1000000,
+                           '',
+                           tx.hash])
+        else:
+            print(f'The transaction "{tx.hash}" has a derived output amount of zero, thus not matching any accointing classification. Skipping..')
+
+        if config.classify_internal_txs:
+            internal = True
+            wtx = wallet.transactions[tx.hash]
+            wtx_utxos = wtx.inputs + wtx.outputs
+            for wtx_utxo in wtx_utxos:
+                if wtx_utxo.address not in config.addresses:
+                    internal = False
+                    break
+            if internal:
+                tx_csv[-1][0] = 'internal'
+
+    return tx_csv
+
+
+def sanity_check_controlled_amount(csv_data) -> float:
+    derived_amount = 0.0
+    for row in csv_data:
+        if row[2] != '':
+            derived_amount = derived_amount + float(row[2])
+        if row[4] != '':
+            derived_amount = derived_amount - float(row[4])
+        if row[6] != '':
+            derived_amount = derived_amount - float(row[6])
+
+    return derived_amount
+
+
+def sanity_check_amount_for_addresses(wallet: Wallet, csv_data) -> float:
+    for address in wallet.addresses:
+        derived_amount = 0.0
+        tx_hashes = []
+        for tx in address.transactions:
+            tx_hashes.append(tx.hash)
+        for row in csv_data:
+            if row[9] in tx_hashes:
+                if row[2] != '':
+                    derived_amount = derived_amount + float(row[2])
+                if row[4] != '':
+                    derived_amount = derived_amount - float(row[4])
+                if row[6] != '':
+                    derived_amount = derived_amount - float(row[6])
+
+    return derived_amount

--- a/exporters/blockpit_exporter.py
+++ b/exporters/blockpit_exporter.py
@@ -9,20 +9,29 @@ csv_header = ['Date (UTC)', 'Integration Name', 'Label', 'Outgoing Asset', 'Outg
 sorting_key = 1
 
 
-def export_reward_history_for_wallet(wallet: Wallet, currency) -> List[Any]:
+def export_reward_history_for_wallet(wallet: Wallet, currency, mastersplit) -> List[Any]:
     rewards = []
+    leftover=0
+    totalleftover=0
     if len(wallet.rewards) > 0:
         for reward in wallet.rewards:
             amount = int(reward.amount) / 1000000
-            classification = ''
             if reward.type == 'member':
-                classification = 'Staking'
-            elif reward.type == 'leader':
-                classification = 'Masternode'
+                 rewards.append([reward.reward_time, wallet.name.split('/')[1], 'Staking', '', '', 'ADA', amount, '', '', '', ''])
             elif reward.type == 'treasury' or reward.type == 'reserves':
-                classification = 'Bounty'
-            rewards.append([reward.reward_time, wallet.name.split('/')[1], classification, '', '', 'ADA', amount, '', '', '', ''])
-
+                rewards.append([reward.reward_time, wallet.name.split('/')[1], 'Bounty', '', '', 'ADA', amount, '', '', '', ''])
+            if reward.type == 'leader':
+                if mastersplit > 0 and amount >= mastersplit:
+                    leftover = amount - mastersplit
+                    totalleftover += leftover
+                    amount = mastersplit
+                rewards.append([reward.reward_time, wallet.name.split('/')[1], 'Masternode', '', '', 'ADA', amount, '', '', '', ''])
+                if (leftover > 0):
+                    rewards.append([reward.reward_time, wallet.name.split('/')[1], 'Non-Taxable In', '', '', 'ADA', leftover, '', '', '', ''])
+                    rewards.append([reward.reward_time, wallet.name.split('/')[1], 'Payment', 'ADA', leftover, '', '', '', '', '', ''])
+                    rewards.append([reward.reward_time, wallet.name.split('/')[1], 'Interest', '', '', 'ADA', leftover, '', '', '', ''])
+    if mastersplit > 0:
+        print(f'---- total interest is: ' + str(totalleftover))
     return rewards
 
 


### PR DESCRIPTION
 --mastersplit MASTERSPLIT
 You can supply an ADA number (e.g. 340) to split masternode deposit as follows: Masternode deposits will be reduced (up) to mastersplit value. If there are left-over masternode rewards, generate three extra transactions with same date as masternode deposit: 1. Deposit transaction of left-over ADA with classification Non-Taxable In 2. Withdraw transaction of left-over ADA
with classification Payment 3. Deposit transaction of left-over ADA with classification Interest. Additionally, after calculation, the total interest ADA within the calculated time window will be displayed on standard out. Note: Currently, this parameter is only implemented for the blockpit exporter